### PR TITLE
Remove .NET Framework 4.6.1 dependency from servicecontrol package

### DIFF
--- a/servicecontrol/servicecontrol.nuspec
+++ b/servicecontrol/servicecontrol.nuspec
@@ -34,9 +34,6 @@ Since this is a portable application, after installation, Particular.ServiceCont
 `choco install servicecontrol --params '"/NoDesktop /NoStartMenu"'`
     </description>
     <tags>servicecontrol nservicebus particular portable</tags>
-    <dependencies>
-      <dependency id="netfx-4.6.2" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Remove .NET Framework 4.6.1 dependency since this was a dependency when there was an MSI installer